### PR TITLE
睡眠予測時、分割睡眠の場合に合計時間が最初の睡眠と最後の睡眠の差になっているのを修正

### DIFF
--- a/src/features/sleep/repositories/predictions.test.ts
+++ b/src/features/sleep/repositories/predictions.test.ts
@@ -67,7 +67,7 @@ describe('getMyPredictions', () => {
         id: 100,
         userId: uuidToBin(userId),
         start: new Date('2022-01-01T00:00:00.000Z'),
-        end: new Date('2022-01-01T02:00:00.000Z'),
+        end: new Date('2022-01-01T04:00:00.000Z'),
       },
       {
         userId: uuidToBin(userId),
@@ -81,7 +81,6 @@ describe('getMyPredictions', () => {
         end: new Date('2022-01-01T06:00:00.000Z'),
         parentSleepId: 100,
       },
-
       testCases[1],
       testCases[2],
     ] satisfies Parameters<typeof sleepFactory.create>[0]
@@ -105,9 +104,8 @@ describe('getMyPredictions', () => {
         id: 100,
         userId: uuidToBin(userId),
         start: new Date('2022-01-01T00:00:00.000Z'),
-        end: new Date('2022-01-01T02:00:00.000Z'),
+        end: new Date('2022-01-01T04:00:00.000Z'),
       },
-
       {
         userId: uuidToBin(userId),
         start: new Date('2022-01-01T04:00:00.000Z'),

--- a/src/features/sleep/utils/predictWithLR/predictWithLR.test.ts
+++ b/src/features/sleep/utils/predictWithLR/predictWithLR.test.ts
@@ -196,10 +196,11 @@ describe('predictWithLR', () => {
         : sleep
     )
 
+    // 分割睡眠の日は睡眠時間が4時間のため予測される睡眠時間は短くなる
     const expected = [
       {
-        start: new Date('2022-01-08T07:00:00.000Z'),
-        end: new Date('2022-01-08T15:00:00.000Z'),
+        start: new Date('2022-01-08T07:15:00.000Z'),
+        end: new Date('2022-01-08T14:45:00.000Z'),
       },
     ]
     const result = predictWithLR(

--- a/src/features/sleep/utils/predictWithLR/predictWithLR.ts
+++ b/src/features/sleep/utils/predictWithLR/predictWithLR.ts
@@ -17,11 +17,16 @@ export const predictWithLR = (
       // 睡眠開始時刻の昇順でソートされているので最後の要素が最も遅い睡眠
       const lastSegmentedSleep =
         sleep.segmentedSleeps[sleep.segmentedSleeps.length - 1]
+      const totalDuration = [sleep, ...sleep.segmentedSleeps].reduce(
+        (total, segmentedSleep) =>
+          total +
+          (getUnixTime(segmentedSleep.end) - getUnixTime(segmentedSleep.start)),
+        0
+      )
       return [
         {
           sleep: { ...sleep, start: sleep.start, end: lastSegmentedSleep.end },
-          duration:
-            getUnixTime(lastSegmentedSleep.end) - getUnixTime(sleep.start),
+          duration: totalDuration,
           sleepMidUnixTime:
             getUnixTime(sleep.start) +
             (getUnixTime(lastSegmentedSleep.end) - getUnixTime(sleep.start)) /


### PR DESCRIPTION
合計時間を分割睡眠らの睡眠時間の合計に変更